### PR TITLE
differentiate entity schema(s)

### DIFF
--- a/schemas.json
+++ b/schemas.json
@@ -1,4 +1,22 @@
 {
+    "Labels": {
+        "type": "object",
+        "additionalProperties": {
+            "$ref": "./schemas.json#/Term"
+        }
+    },
+    "Descriptions": {
+        "type": "object",
+        "additionalProperties": {
+            "$ref": "./schemas.json#/Term"
+        }
+    },
+    "Aliases": {
+        "type": "object",
+        "additionalProperties": {
+            "$ref": "./schemas.json#/AliasList"
+        }
+    },
     "AliasList": {
         "type": "array",
         "items": { "$ref": "./schemas.json#/Term" }
@@ -11,9 +29,8 @@
         },
         "required": [ "code", "message" ]
     },
-    "Entity": { "type": "object" },
     "DocumentPatch": {
-        "description": "A JSONPatch object as defined by RFC 6902", 
+        "description": "A JSONPatch object as defined by RFC 6902",
         "type": "object",
         "properties": {
             "op": {
@@ -30,6 +47,95 @@
             }
         },
         "required": ["op", "path"]
+    },
+    "Item": {
+        "allOf": [
+            {
+                "$ref": "./schemas.json#/Entity"
+            },
+            {
+                "$ref": "./schemas.json#/Fingerprintable"
+            },
+            {
+                "$ref": "./schemas.json#/StatementsBearing"
+            }
+        ]
+    },
+    "Property": {
+        "allOf": [
+            {
+                "$ref": "./schemas.json#/Entity"
+            },
+            {
+                "$ref": "./schemas.json#/Fingerprintable"
+            },
+            {
+                "$ref": "./schemas.json#/StatementsBearing"
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "datatype": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "datatype"
+                ]
+            }
+        ]
+    },
+    "Fingerprintable": {
+        "type": "object",
+        "properties": {
+            "labels": {
+                "$ref": "./schemas.json#/Labels"
+            },
+            "descriptions": {
+                "$ref": "./schemas.json#/Descriptions"
+            },
+            "aliases": {
+                "$ref": "./schemas.json#/Aliases"
+            }
+        },
+        "required": [
+            "labels",
+            "descriptions",
+            "aliases"
+        ]
+    },
+    "StatementsBearing": {
+        "type": "object",
+        "properties": {
+            "statements": {
+                "type": "object"
+            }
+        },
+        "required": [
+            "statements"
+        ]
+    },
+    "Entity": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "type": {
+                "type": "string"
+            },
+            "modified": {
+                "type": "string",
+                "format": "date-time"
+            }
+        },
+		"required": [
+            "id",
+            "type"
+        ],
+        "discriminator": {
+            "propertyName": "type"
+        }
     },
     "Term": {
         "type": "object",


### PR DESCRIPTION
I'm unsure about what exactle "required" fields entail. In requests? In
responses?

Organizes Fingerprintable and StatementsBearing into features which can
be mixed into certain entities - a bit opinionated but I think it makes
sense (names are open for discussion, clearly).

Does not further describe statements yet.

Would be great if we could somehow deprioritize the "internal" types (e.g.
Fingerprintable/Term) somehow so they don't clutter the view.